### PR TITLE
feat: support custom project fields

### DIFF
--- a/dist/api/github-projectv2-api.d.ts
+++ b/dist/api/github-projectv2-api.d.ts
@@ -26,6 +26,7 @@ export declare class Project {
 export declare const fetchProjectItems: (login: string, isOrg: boolean, projectNumber: number, token: string, progress?: ((loaded: number, total: number) => void) | undefined) => Promise<ProjectItem[]>;
 export declare class ProjectItem {
     node: any;
+    fields: ProjectFieldValue[];
     constructor(node: any);
     getCreatedAt(): string | undefined;
     isArchived(): boolean | undefined;
@@ -49,3 +50,29 @@ export declare class ProjectItem {
     getTitle(): string | undefined;
     getUrl(): string | undefined;
 }
+export declare const fetchProjectFields: (login: string, isOrg: boolean, projectNumber: number, token: string, progress?: ((loaded: number, total: number) => void) | undefined) => Promise<ProjectField[]>;
+declare enum ProjectFieldType {
+    ProjectV2ItemFieldDateValue = "ProjectV2ItemFieldDateValue",
+    ProjectV2ItemFieldLabelValue = "ProjectV2ItemFieldLabelValue",
+    ProjectV2ItemFieldNumberValue = "ProjectV2ItemFieldNumberValue",
+    ProjectV2ItemFieldPullRequestValue = "ProjectV2ItemFieldPullRequestValue",
+    ProjectV2ItemFieldSingleSelectValue = "ProjectV2ItemFieldSingleSelectValue",
+    ProjectV2ItemFieldTextValue = "ProjectV2ItemFieldTextValue",
+    ProjectV2ItemFieldUserValue = "ProjectV2ItemFieldUserValue",
+    ProjectV2ItemFieldRepositoryValue = "ProjectV2ItemFieldRepositoryValue",
+    ProjectV2ItemFieldReviewerValue = "ProjectV2ItemFieldReviewerValue"
+}
+export declare class ProjectField {
+    node: any;
+    constructor(node: any);
+    getName(): string | undefined;
+    getId(): string | undefined;
+}
+export declare class ProjectFieldValue {
+    node: any;
+    field: ProjectField;
+    constructor(node: any);
+    getType(): ProjectFieldType | undefined;
+    getValue(): string | number | undefined;
+}
+export {};

--- a/dist/components/GitHubProjectExporter.js
+++ b/dist/components/GitHubProjectExporter.js
@@ -1,4 +1,13 @@
 "use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
@@ -6,7 +15,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.GitHubProjectExporter = exports.exporterPath = void 0;
 require("bootstrap/dist/css/bootstrap.css");
 const emoji_regex_1 = __importDefault(require("emoji-regex"));
-const export_to_csv_1 = require("export-to-csv");
+const json_2_csv_1 = require("json-2-csv");
 const react_1 = __importDefault(require("react"));
 const react_bootstrap_1 = require("react-bootstrap");
 const github_projectv2_api_1 = require("../api/github-projectv2-api");
@@ -32,6 +41,10 @@ const GitHubProjectExporter = (props) => {
     const [knownColumnsText] = (0, useLocalStorageState_1.useLocalStorageState)(GitHubProjectExporterSettings_1.EXPORTER_KNOWN_COLUMNS_DEFAULT, GitHubProjectExporterSettings_1.EXPORTER_KNOWN_COLUMNS_KEY);
     const knownColumns = (knownColumnsText !== null && knownColumnsText !== void 0 ? knownColumnsText : '').split(',').filter((c) => !!c);
     const selectedColumnNames = (columnFilterText !== null && columnFilterText !== void 0 ? columnFilterText : '').split(',').filter((c) => !!c);
+    const [knownFieldsText, setKnownFieldsText] = (0, useLocalStorageState_1.useLocalStorageState)('', GitHubProjectExporterSettings_1.EXPORTER_KNOWN_FIELDS_KEY);
+    const [fieldsFilterEnabled, setFieldsFilterEnabled] = (0, useLocalStorageState_1.useLocalStorageState)('true', GitHubProjectExporterSettings_1.EXPORTER_FIELD_FILTER_ENABLED_KEY);
+    const [fieldsFilterText, setFieldsFilterText] = (0, useLocalStorageState_1.useLocalStorageState)(knownFieldsText, GitHubProjectExporterSettings_1.EXPORTER_FIELD_FILTER_TEXT_KEY);
+    const selectedFieldsNames = (fieldsFilterText !== null && fieldsFilterText !== void 0 ? fieldsFilterText : '').split(',').filter((c) => !!c);
     const [projects, setProjects] = react_1.default.useState(undefined);
     const [loadProjectsError, setLoadProjectsError] = react_1.default.useState(undefined);
     const [exportProjectItemsError, setExportProjectItemsError] = react_1.default.useState(undefined);
@@ -101,25 +114,23 @@ const GitHubProjectExporter = (props) => {
                     var _a, _b, _c, _d, _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v;
                     const rawTitle = (_a = item.getTitle()) !== null && _a !== void 0 ? _a : '';
                     const rawStatus = (_b = item.getStatus()) !== null && _b !== void 0 ? _b : '';
-                    return {
+                    return item.fields.reduce((acc, fieldVal) => {
+                        var _a;
+                        // selected field filtering
+                        const fieldName = fieldVal.field.getName();
+                        if (!fieldName)
+                            return acc;
+                        if (fieldsFilterEnabled === 'true' && !selectedFieldsNames.includes(fieldName))
+                            return acc;
+                        // custom fields can overwrite pre-added fields; this is intentional
+                        return Object.assign(Object.assign({}, acc), { [fieldName]: (_a = fieldVal.getValue()) !== null && _a !== void 0 ? _a : '' });
+                    }, Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({}, (selectedFieldsNames.includes('Title') && {
                         Title: (removeTitleEmojis === 'true' ? rawTitle.split((0, emoji_regex_1.default)()).join('') : rawTitle).trim(),
-                        Number: (_c = item.getNumber()) !== null && _c !== void 0 ? _c : '',
-                        Status: (removeStatusEmojis === 'true' ? rawStatus.split((0, emoji_regex_1.default)()).join('') : rawStatus).trim(),
+                    })), { Number: (_c = item.getNumber()) !== null && _c !== void 0 ? _c : '', Status: (removeStatusEmojis === 'true' ? rawStatus.split((0, emoji_regex_1.default)()).join('') : rawStatus).trim() }), (selectedFieldsNames.includes('Assignees') && {
                         Assignees: (_e = (_d = item
                             .getAssignees()) === null || _d === void 0 ? void 0 : _d.map((a) => a.name).join(', ')) !== null && _e !== void 0 ? _e : '',
-                        'Assignee Usernames': (_g = (_f = item
-                            .getAssignees()) === null || _f === void 0 ? void 0 : _f.map((a) => a.login).join(', ')) !== null && _g !== void 0 ? _g : '',
-                        Labels: (_j = (_h = item.getLabels()) === null || _h === void 0 ? void 0 : _h.join(', ')) !== null && _j !== void 0 ? _j : '',
-                        URL: (_k = item.getUrl()) !== null && _k !== void 0 ? _k : '',
-                        Milestone: (_l = item.getMilestone()) !== null && _l !== void 0 ? _l : '',
-                        Author: (_o = (_m = item.getAuthor()) === null || _m === void 0 ? void 0 : _m.name) !== null && _o !== void 0 ? _o : '',
-                        'Author Username': (_q = (_p = item.getAuthor()) === null || _p === void 0 ? void 0 : _p.login) !== null && _q !== void 0 ? _q : '',
-                        CreatedAt: (_r = item.getCreatedAt()) !== null && _r !== void 0 ? _r : '',
-                        UpdatedAt: (_s = item.getUpdatedAt()) !== null && _s !== void 0 ? _s : '',
-                        ClosedAt: (_t = item.getClosedAt()) !== null && _t !== void 0 ? _t : '',
-                        Type: (_u = item.getType()) !== null && _u !== void 0 ? _u : '',
-                        State: (_v = item.getState()) !== null && _v !== void 0 ? _v : '',
-                    };
+                    })), { 'Assignee Usernames': (_g = (_f = item
+                            .getAssignees()) === null || _f === void 0 ? void 0 : _f.map((a) => a.login).join(', ')) !== null && _g !== void 0 ? _g : '' }), (selectedFieldsNames.includes('Labels') && { Labels: (_j = (_h = item.getLabels()) === null || _h === void 0 ? void 0 : _h.join(', ')) !== null && _j !== void 0 ? _j : '' })), { URL: (_k = item.getUrl()) !== null && _k !== void 0 ? _k : '' }), (selectedFieldsNames.includes('Milestone') && { Milestone: (_l = item.getMilestone()) !== null && _l !== void 0 ? _l : '' })), { Author: (_o = (_m = item.getAuthor()) === null || _m === void 0 ? void 0 : _m.name) !== null && _o !== void 0 ? _o : '', 'Author Username': (_q = (_p = item.getAuthor()) === null || _p === void 0 ? void 0 : _p.login) !== null && _q !== void 0 ? _q : '', CreatedAt: (_r = item.getCreatedAt()) !== null && _r !== void 0 ? _r : '', UpdatedAt: (_s = item.getUpdatedAt()) !== null && _s !== void 0 ? _s : '', ClosedAt: (_t = item.getClosedAt()) !== null && _t !== void 0 ? _t : '', Type: (_u = item.getType()) !== null && _u !== void 0 ? _u : '', State: (_v = item.getState()) !== null && _v !== void 0 ? _v : '' }));
                 });
                 // The en-ZA locale uses YYYY/MM/DD. We then replace all / with -.
                 // See: https://stackoverflow.com/questions/23593052/format-javascript-date-as-yyyy-mm-dd
@@ -176,23 +187,31 @@ const GitHubProjectExporter = (props) => {
                             " Export CSV")),
                     currentlyExporting && (react_1.default.createElement(react_bootstrap_1.ProgressBar, { animated: true, variant: "success", now: loadPercentage, label: `${loadPercentage}%` }))))));
     });
-    const exportCsv = (jsonData, filename) => {
-        // https://www.npmjs.com/package/export-to-csv
-        const options = {
-            fieldSeparator: ',',
-            quoteStrings: '"',
-            decimalSeparator: '.',
-            showLabels: true,
-            useTextFile: false,
-            filename,
-            useBom: true,
-            useKeysAsHeaders: true,
-        };
-        const csvExporter = new export_to_csv_1.ExportToCsv(options);
-        csvExporter.generateCsv(jsonData);
+    // adapted from https://stackoverflow.com/a/63965930/8396479
+    const promptDownload = (blob, filename) => {
+        var _a;
+        const url = window.URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        link.setAttribute('download', filename);
+        // Append to html link element page
+        document.body.appendChild(link);
+        // Start download
+        link.click();
+        // Clean up and remove the link
+        (_a = link.parentNode) === null || _a === void 0 ? void 0 : _a.removeChild(link);
     };
+    const exportCsv = (jsonData, filename) => __awaiter(void 0, void 0, void 0, function* () {
+        // https://npm.one/package/json-2-csv
+        const csv = yield (0, json_2_csv_1.json2csvAsync)(jsonData, {
+            emptyFieldValue: '',
+            excelBOM: true,
+        });
+        promptDownload(new Blob([csv], { type: 'text/csv;charset=utf8;' }), `${filename}.csv`);
+    });
     const validSettings = accessToken && login;
     const selectedColumnElements = selectedColumnNames.map((col, index) => (react_1.default.createElement(react_bootstrap_1.Badge, { key: `${col}-${index}`, bg: "primary" }, col)));
+    const selectedFieldsElements = selectedFieldsNames.map((field, index) => (react_1.default.createElement(react_bootstrap_1.Badge, { key: `${field}-${index}`, bg: "primary" }, field)));
     return (react_1.default.createElement("div", Object.assign({}, props, { style: Object.assign({}, props.style) }),
         react_1.default.createElement(react_bootstrap_1.Container, null,
             react_1.default.createElement(react_bootstrap_1.Row, null,
@@ -303,7 +322,10 @@ const GitHubProjectExporter = (props) => {
                                                 react_1.default.createElement(react_bootstrap_1.Badge, { bg: removeTitleEmojis === 'true' ? 'primary' : 'secondary', style: { fontVariant: 'small-caps' } }, removeTitleEmojis === 'true' ? 'yes' : 'no'))),
                                         react_1.default.createElement("tr", null,
                                             react_1.default.createElement("td", null, "Statuses included"),
-                                            react_1.default.createElement("td", null, columnFilterEnabled === 'true' ? (react_1.default.createElement("div", { className: "d-flex flex-wrap gap-1" }, selectedColumnElements.length > 0 ? (selectedColumnElements) : (react_1.default.createElement(react_bootstrap_1.Badge, { bg: "danger" }, "None")))) : (react_1.default.createElement(react_bootstrap_1.Badge, { bg: "primary" }, "Include all statuses")))))),
+                                            react_1.default.createElement("td", null, columnFilterEnabled === 'true' ? (react_1.default.createElement("div", { className: "d-flex flex-wrap gap-1" }, selectedColumnElements.length > 0 ? (selectedColumnElements) : (react_1.default.createElement(react_bootstrap_1.Badge, { bg: "danger" }, "None")))) : (react_1.default.createElement(react_bootstrap_1.Badge, { bg: "primary" }, "Include all statuses")))),
+                                        react_1.default.createElement("tr", null,
+                                            react_1.default.createElement("td", null, "Fields included"),
+                                            react_1.default.createElement("td", null, fieldsFilterEnabled === 'true' ? (react_1.default.createElement("div", { className: "d-flex flex-wrap gap-1" }, selectedFieldsNames.length > 0 ? (selectedFieldsElements) : (react_1.default.createElement(react_bootstrap_1.Badge, { bg: "danger" }, "None")))) : (react_1.default.createElement(react_bootstrap_1.Badge, { bg: "primary" }, "Include all fields")))))),
                                 react_1.default.createElement("div", { className: "d-flex justify-content-end" },
                                     react_1.default.createElement("a", { href: GitHubProjectExporterSettings_1.settingsPath },
                                         react_1.default.createElement(react_bootstrap_1.Button, { variant: "primary" }, "Change Settings"))))))))))));

--- a/dist/components/GitHubProjectExporter.js
+++ b/dist/components/GitHubProjectExporter.js
@@ -124,13 +124,31 @@ const GitHubProjectExporter = (props) => {
                             return acc;
                         // custom fields can overwrite pre-added fields; this is intentional
                         return Object.assign(Object.assign({}, acc), { [fieldName]: (_a = fieldVal.getValue()) !== null && _a !== void 0 ? _a : '' });
-                    }, Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({}, (selectedFieldsNames.includes('Title') && {
+                    }, Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign(Object.assign({}, (selectedFieldsNames.includes('Title') && {
                         Title: (removeTitleEmojis === 'true' ? rawTitle.split((0, emoji_regex_1.default)()).join('') : rawTitle).trim(),
-                    })), { Number: (_c = item.getNumber()) !== null && _c !== void 0 ? _c : '', Status: (removeStatusEmojis === 'true' ? rawStatus.split((0, emoji_regex_1.default)()).join('') : rawStatus).trim() }), (selectedFieldsNames.includes('Assignees') && {
+                    })), (selectedFieldsNames.includes('Number') && {
+                        Number: (_c = item.getNumber()) !== null && _c !== void 0 ? _c : '',
+                    })), { Status: (removeStatusEmojis === 'true' ? rawStatus.split((0, emoji_regex_1.default)()).join('') : rawStatus).trim() }), (selectedFieldsNames.includes('Assignees') && {
                         Assignees: (_e = (_d = item
                             .getAssignees()) === null || _d === void 0 ? void 0 : _d.map((a) => a.name).join(', ')) !== null && _e !== void 0 ? _e : '',
-                    })), { 'Assignee Usernames': (_g = (_f = item
-                            .getAssignees()) === null || _f === void 0 ? void 0 : _f.map((a) => a.login).join(', ')) !== null && _g !== void 0 ? _g : '' }), (selectedFieldsNames.includes('Labels') && { Labels: (_j = (_h = item.getLabels()) === null || _h === void 0 ? void 0 : _h.join(', ')) !== null && _j !== void 0 ? _j : '' })), { URL: (_k = item.getUrl()) !== null && _k !== void 0 ? _k : '' }), (selectedFieldsNames.includes('Milestone') && { Milestone: (_l = item.getMilestone()) !== null && _l !== void 0 ? _l : '' })), { Author: (_o = (_m = item.getAuthor()) === null || _m === void 0 ? void 0 : _m.name) !== null && _o !== void 0 ? _o : '', 'Author Username': (_q = (_p = item.getAuthor()) === null || _p === void 0 ? void 0 : _p.login) !== null && _q !== void 0 ? _q : '', CreatedAt: (_r = item.getCreatedAt()) !== null && _r !== void 0 ? _r : '', UpdatedAt: (_s = item.getUpdatedAt()) !== null && _s !== void 0 ? _s : '', ClosedAt: (_t = item.getClosedAt()) !== null && _t !== void 0 ? _t : '', Type: (_u = item.getType()) !== null && _u !== void 0 ? _u : '', State: (_v = item.getState()) !== null && _v !== void 0 ? _v : '' }));
+                    })), (selectedFieldsNames.includes('Assignee Usernames') && {
+                        'Assignee Usernames': (_g = (_f = item
+                            .getAssignees()) === null || _f === void 0 ? void 0 : _f.map((a) => a.login).join(', ')) !== null && _g !== void 0 ? _g : '',
+                    })), (selectedFieldsNames.includes('Labels') && { Labels: (_j = (_h = item.getLabels()) === null || _h === void 0 ? void 0 : _h.join(', ')) !== null && _j !== void 0 ? _j : '' })), (selectedFieldsNames.includes('URL') && {
+                        URL: (_k = item.getUrl()) !== null && _k !== void 0 ? _k : '',
+                    })), (selectedFieldsNames.includes('Milestone') && { Milestone: (_l = item.getMilestone()) !== null && _l !== void 0 ? _l : '' })), (selectedFieldsNames.includes('Author') && { Author: (_o = (_m = item.getAuthor()) === null || _m === void 0 ? void 0 : _m.name) !== null && _o !== void 0 ? _o : '' })), (selectedFieldsNames.includes('Author Username') && {
+                        'Author Username': (_q = (_p = item.getAuthor()) === null || _p === void 0 ? void 0 : _p.login) !== null && _q !== void 0 ? _q : '',
+                    })), (selectedFieldsNames.includes('CreatedAt') && {
+                        CreatedAt: (_r = item.getCreatedAt()) !== null && _r !== void 0 ? _r : '',
+                    })), (selectedFieldsNames.includes('UpdatedAt') && {
+                        UpdatedAt: (_s = item.getUpdatedAt()) !== null && _s !== void 0 ? _s : '',
+                    })), (selectedFieldsNames.includes('ClosedAt') && {
+                        ClosedAt: (_t = item.getClosedAt()) !== null && _t !== void 0 ? _t : '',
+                    })), (selectedFieldsNames.includes('Type') && {
+                        Type: (_u = item.getType()) !== null && _u !== void 0 ? _u : '',
+                    })), (selectedFieldsNames.includes('State') && {
+                        State: (_v = item.getState()) !== null && _v !== void 0 ? _v : '',
+                    })));
                 });
                 // The en-ZA locale uses YYYY/MM/DD. We then replace all / with -.
                 // See: https://stackoverflow.com/questions/23593052/format-javascript-date-as-yyyy-mm-dd

--- a/dist/components/GitHubProjectExporterSettings.d.ts
+++ b/dist/components/GitHubProjectExporterSettings.d.ts
@@ -14,6 +14,9 @@ export declare const EXPORTER_KNOWN_COLUMNS_KEY: string;
 export declare const EXPORTER_KNOWN_COLUMNS_DEFAULT = "Todo,In Progress,Done";
 export declare const EXPORTER_COLUMN_FILTER_ENABLED_KEY: string;
 export declare const EXPORTER_COLUMN_FILTER_TEXT_KEY: string;
+export declare const EXPORTER_KNOWN_FIELDS_KEY: string;
+export declare const EXPORTER_FIELD_FILTER_ENABLED_KEY: string;
+export declare const EXPORTER_FIELD_FILTER_TEXT_KEY: string;
 export declare const settingsPath = "/github-projectv2-csv-exporter/?path=/story/tools-github-project-exporter--settings";
 export interface GitHubExporterSettingsProps extends DivProps {
 }

--- a/dist/components/GitHubProjectExporterSettings.js
+++ b/dist/components/GitHubProjectExporterSettings.js
@@ -14,12 +14,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.GitHubExporterSettings = exports.settingsPath = exports.EXPORTER_COLUMN_FILTER_TEXT_KEY = exports.EXPORTER_COLUMN_FILTER_ENABLED_KEY = exports.EXPORTER_KNOWN_COLUMNS_DEFAULT = exports.EXPORTER_KNOWN_COLUMNS_KEY = exports.EXPORTER_REMOVE_TITLE_EMOJIS_KEY = exports.EXPORTER_REMOVE_STATUS_EMOJIS_KEY = exports.EXPORTER_INCLUDE_CLOSED_ITEMS_KEY = exports.EXPORTER_INCLUDE_DRAFT_ISSUES_KEY = exports.EXPORTER_INCLUDE_PULL_REQUESTS_KEY = exports.EXPORTER_INCLUDE_ISSUES_KEY = exports.EXPORTER_IS_ORG_KEY = exports.EXPORTER_LOGIN_KEY = exports.EXPORTER_ACCESS_TOKEN_KEY = void 0;
+exports.GitHubExporterSettings = exports.settingsPath = exports.EXPORTER_FIELD_FILTER_TEXT_KEY = exports.EXPORTER_FIELD_FILTER_ENABLED_KEY = exports.EXPORTER_KNOWN_FIELDS_KEY = exports.EXPORTER_COLUMN_FILTER_TEXT_KEY = exports.EXPORTER_COLUMN_FILTER_ENABLED_KEY = exports.EXPORTER_KNOWN_COLUMNS_DEFAULT = exports.EXPORTER_KNOWN_COLUMNS_KEY = exports.EXPORTER_REMOVE_TITLE_EMOJIS_KEY = exports.EXPORTER_REMOVE_STATUS_EMOJIS_KEY = exports.EXPORTER_INCLUDE_CLOSED_ITEMS_KEY = exports.EXPORTER_INCLUDE_DRAFT_ISSUES_KEY = exports.EXPORTER_INCLUDE_PULL_REQUESTS_KEY = exports.EXPORTER_INCLUDE_ISSUES_KEY = exports.EXPORTER_IS_ORG_KEY = exports.EXPORTER_LOGIN_KEY = exports.EXPORTER_ACCESS_TOKEN_KEY = void 0;
 require("bootstrap/dist/css/bootstrap.css");
 const classnames_1 = __importDefault(require("classnames"));
 const react_1 = __importDefault(require("react"));
 const react_bootstrap_1 = require("react-bootstrap");
 const GitHubProjectExporter_1 = require("./GitHubProjectExporter");
+const GitHubProjectFieldSettings_1 = require("./GitHubProjectFieldSettings");
 const useLocalStorageState_1 = require("./useLocalStorageState");
 const KEY_PREFIX = `github-projectv2-csv-exporter`;
 exports.EXPORTER_ACCESS_TOKEN_KEY = `${KEY_PREFIX}.token`;
@@ -35,6 +36,9 @@ exports.EXPORTER_KNOWN_COLUMNS_KEY = `${KEY_PREFIX}.known-columns`;
 exports.EXPORTER_KNOWN_COLUMNS_DEFAULT = `Todo,In Progress,Done`;
 exports.EXPORTER_COLUMN_FILTER_ENABLED_KEY = `${KEY_PREFIX}.column-filter-enabled`;
 exports.EXPORTER_COLUMN_FILTER_TEXT_KEY = `${KEY_PREFIX}.column-filter-text`;
+exports.EXPORTER_KNOWN_FIELDS_KEY = `${KEY_PREFIX}.known-fields`;
+exports.EXPORTER_FIELD_FILTER_ENABLED_KEY = `${KEY_PREFIX}.field-filter-enabled`;
+exports.EXPORTER_FIELD_FILTER_TEXT_KEY = `${KEY_PREFIX}.field-filter-text`;
 exports.settingsPath = '/github-projectv2-csv-exporter/?path=/story/tools-github-project-exporter--settings';
 /**
  * Settings for the GitHub project exporter.
@@ -157,6 +161,7 @@ const GitHubExporterSettings = (_a) => {
                                             react_1.default.createElement("div", null,
                                                 react_1.default.createElement(react_bootstrap_1.Form.Control, { type: "text", value: knownColumnsText !== null && knownColumnsText !== void 0 ? knownColumnsText : '', placeholder: knownColumnsText ? '' : 'Add a status above', onChange: (e) => setKnownColumnsText(e.target.value), style: { width: 220 } }))))),
                                 react_1.default.createElement(react_bootstrap_1.Form.Text, { className: "text-muted" }, "Optionally, you can add the status names from your project's boards if you'd like to filter your results based on specific statuses. Adding Known Statuses makes it easier to filter using the \"Only include issues in the following statuses\" setting above. Your CSV will also sort cards in the order these known statuses appear.")),
+                            react_1.default.createElement(GitHubProjectFieldSettings_1.GitHubProjectFieldSettings, null),
                             react_1.default.createElement("div", { className: "d-flex justify-content-end mt-4" },
                                 react_1.default.createElement("a", { href: GitHubProjectExporter_1.exporterPath },
                                     react_1.default.createElement(react_bootstrap_1.Button, { variant: "primary" }, "Open Exporter"))))))))));

--- a/dist/components/GitHubProjectFieldSettings.d.ts
+++ b/dist/components/GitHubProjectFieldSettings.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="react" />
+import { DivProps } from 'react-html-props';
+export interface GitHubExporterProjectFieldSettings extends DivProps {
+}
+/**
+ * Select which fields are included/excluded from the CSV export
+ */
+export declare const GitHubProjectFieldSettings: ({ ...props }: GitHubExporterProjectFieldSettings) => JSX.Element;

--- a/dist/components/GitHubProjectFieldSettings.js
+++ b/dist/components/GitHubProjectFieldSettings.js
@@ -20,6 +20,22 @@ const react_bootstrap_1 = require("react-bootstrap");
 const github_projectv2_api_1 = require("../api/github-projectv2-api");
 const GitHubProjectExporterSettings_1 = require("./GitHubProjectExporterSettings");
 const useLocalStorageState_1 = require("./useLocalStorageState");
+const EXPORTER_BUILTIN_FIELDS = [
+    'Title',
+    'Number',
+    'Assignees',
+    'Assignee Usernames',
+    'Labels',
+    'URL',
+    'Milestone',
+    'Author',
+    'Author Username',
+    'CreatedAt',
+    'UpdatedAt',
+    'ClosedAt',
+    'Type',
+    'State',
+];
 /**
  * Select which fields are included/excluded from the CSV export
  */
@@ -69,8 +85,11 @@ const GitHubProjectFieldSettings = (_a) => {
         if (accessToken && login && loading) {
             (0, github_projectv2_api_1.fetchProjectFields)(login, isOrg === 'true', 1, accessToken)
                 .then((newProjectFields) => {
-                setProjectFields(newProjectFields);
-                const newKnownFieldsText = newProjectFields.map((f) => f.getName()).join(',');
+                const mergedProjectFields = [
+                    ...new Set([...EXPORTER_BUILTIN_FIELDS, ...newProjectFields.map((f) => { var _a; return (_a = f.getName()) !== null && _a !== void 0 ? _a : ''; })]),
+                ];
+                setProjectFields(mergedProjectFields);
+                const newKnownFieldsText = mergedProjectFields.join(',');
                 setKnownFieldsText(newKnownFieldsText);
                 //toggle all fields enabled - only on first load
                 if (fieldsFilterEnabled === 'false' && fieldsFilterText === '')

--- a/dist/components/GitHubProjectFieldSettings.js
+++ b/dist/components/GitHubProjectFieldSettings.js
@@ -1,0 +1,125 @@
+"use strict";
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.GitHubProjectFieldSettings = void 0;
+const react_1 = __importDefault(require("react"));
+const react_bootstrap_1 = require("react-bootstrap");
+const github_projectv2_api_1 = require("../api/github-projectv2-api");
+const GitHubProjectExporterSettings_1 = require("./GitHubProjectExporterSettings");
+const useLocalStorageState_1 = require("./useLocalStorageState");
+/**
+ * Select which fields are included/excluded from the CSV export
+ */
+const GitHubProjectFieldSettings = (_a) => {
+    var props = __rest(_a, []);
+    const [accessToken] = (0, useLocalStorageState_1.useLocalStorageState)('', GitHubProjectExporterSettings_1.EXPORTER_ACCESS_TOKEN_KEY);
+    const [isOrg] = (0, useLocalStorageState_1.useLocalStorageState)('true', GitHubProjectExporterSettings_1.EXPORTER_IS_ORG_KEY);
+    const [login] = (0, useLocalStorageState_1.useLocalStorageState)('', GitHubProjectExporterSettings_1.EXPORTER_LOGIN_KEY);
+    const [projectFields, setProjectFields] = react_1.default.useState(undefined);
+    const [loadProjectFieldsError, setLoadProjectFieldsError] = react_1.default.useState(undefined);
+    const [loading, setLoading] = react_1.default.useState(true);
+    const [knownFieldsText, setKnownFieldsText] = (0, useLocalStorageState_1.useLocalStorageState)('', GitHubProjectExporterSettings_1.EXPORTER_KNOWN_FIELDS_KEY);
+    const [fieldsFilterEnabled, setFieldsFilterEnabled] = (0, useLocalStorageState_1.useLocalStorageState)('false', GitHubProjectExporterSettings_1.EXPORTER_FIELD_FILTER_ENABLED_KEY);
+    const [fieldsFilterText, setFieldsFilterText] = (0, useLocalStorageState_1.useLocalStorageState)(knownFieldsText, GitHubProjectExporterSettings_1.EXPORTER_FIELD_FILTER_TEXT_KEY);
+    const [enteredKnownFields, setEnteredKnownFields] = react_1.default.useState('');
+    const knownFieldsRef = react_1.default.useRef(null);
+    const selectedFieldsNames = (fieldsFilterText !== null && fieldsFilterText !== void 0 ? fieldsFilterText : '').split(',').filter((c) => !!c);
+    const knownFields = (knownFieldsText !== null && knownFieldsText !== void 0 ? knownFieldsText : '').split(',').filter((c) => !!c);
+    const addKnownField = (col) => {
+        setKnownFieldsText([...new Set([...knownFields, col.trim()])].join(','));
+    };
+    const deleteKnownField = (col) => {
+        const colsCopy = [...knownFields];
+        colsCopy.splice(colsCopy.indexOf(col), 1);
+        setKnownFieldsText(colsCopy.join(','));
+    };
+    const fieldNameBadgeElements = knownFields.map((colName, index) => {
+        const selected = selectedFieldsNames.includes(colName);
+        return (react_1.default.createElement(react_bootstrap_1.Badge, { key: `col-${index}`, bg: selected ? 'primary' : 'light', className: `user-select-none ${selected ? '' : 'text-black'}`, onClick: () => {
+                if (!selected) {
+                    setFieldsFilterText([...new Set([...selectedFieldsNames, colName])].join(','));
+                    setFieldsFilterEnabled('true');
+                }
+                else {
+                    const newNames = [...selectedFieldsNames];
+                    newNames.splice(newNames.indexOf(colName), 1);
+                    setFieldsFilterText(newNames.join(','));
+                    setFieldsFilterEnabled(`${newNames.length > 0}`);
+                }
+            }, style: { cursor: 'pointer' } }, colName));
+    });
+    const knownFieldsElements = knownFields.map((field, index) => (react_1.default.createElement(react_bootstrap_1.Badge, { key: `known-col-${index}`, bg: "primary" },
+        react_1.default.createElement("div", { className: "d-flex gap-2 align-items-center" },
+            field,
+            react_1.default.createElement("span", { className: "fw-bold", style: { cursor: 'pointer', fontSize: '120%' }, onClick: () => deleteKnownField(field) }, "\u00D7")))));
+    react_1.default.useEffect(() => {
+        if (accessToken && login && loading) {
+            (0, github_projectv2_api_1.fetchProjectFields)(login, isOrg === 'true', 1, accessToken)
+                .then((newProjectFields) => {
+                setProjectFields(newProjectFields);
+                const newKnownFieldsText = newProjectFields.map((f) => f.getName()).join(',');
+                setKnownFieldsText(newKnownFieldsText);
+                //toggle all fields enabled - only on first load
+                if (fieldsFilterEnabled === 'false' && fieldsFilterText === '')
+                    setFieldsFilterText(newKnownFieldsText);
+            })
+                .catch((e) => {
+                console.error(e);
+                setLoadProjectFieldsError(e);
+            })
+                .finally(() => setLoading(false));
+        }
+    }, [accessToken, login, loading, isOrg]);
+    return (react_1.default.createElement("div", Object.assign({}, props, { style: Object.assign({}, props.style) }),
+        !!loading && (react_1.default.createElement("div", { className: "d-flex justify-content-center align-items-center", style: { height: 120 } },
+            react_1.default.createElement(react_bootstrap_1.Spinner, { animation: "border", role: "status" }))),
+        loadProjectFieldsError && (react_1.default.createElement(react_bootstrap_1.Alert, { variant: "danger", className: "mb-2" },
+            react_1.default.createElement("p", { className: "fw-bold" },
+                "Could not load project fields for",
+                ' ',
+                react_1.default.createElement(react_bootstrap_1.Badge, { bg: "danger", className: "font-monospace" }, login),
+                ". Please check your access token and login."),
+            react_1.default.createElement("p", { className: "mb-0 font-monospace small" }, `${loadProjectFieldsError}`))),
+        !loading && !!projectFields && (react_1.default.createElement(react_1.default.Fragment, null,
+            react_1.default.createElement(react_bootstrap_1.Form.Group, { controlId: "fg-fields-filter", className: "mb-3" },
+                react_1.default.createElement("div", { className: "d-flex flex-wrap align-items-center gap-2 mb-2" },
+                    react_1.default.createElement(react_bootstrap_1.Form.Check, { label: "Include the following fields:", id: "fields-filter-checkbox", checked: fieldsFilterEnabled === 'true', onChange: (e) => setFieldsFilterEnabled(`${e.target.checked}`), className: "user-select-none" }),
+                    react_1.default.createElement(react_bootstrap_1.Form.Control, { type: "text", value: fieldsFilterText !== null && fieldsFilterText !== void 0 ? fieldsFilterText : '', placeholder: fieldsFilterEnabled !== 'true' ? '' : 'Enter field name', onChange: (e) => setFieldsFilterText(e.target.value), style: { width: 220 }, disabled: fieldsFilterEnabled !== 'true' })),
+                react_1.default.createElement("div", { className: "d-flex flex-wrap gap-2 ms-4" }, fieldNameBadgeElements)),
+            react_1.default.createElement(react_bootstrap_1.Form.Group, { controlId: "known-fields-groups", className: "mb-3" },
+                react_1.default.createElement(react_bootstrap_1.Accordion, null,
+                    react_1.default.createElement(react_bootstrap_1.Accordion.Item, { eventKey: "0" },
+                        react_1.default.createElement(react_bootstrap_1.Accordion.Header, null,
+                            react_1.default.createElement("div", { className: "d-flex gap-2" },
+                                "Item Fields",
+                                react_1.default.createElement(react_bootstrap_1.Badge, { pill: true, bg: projectFields.length > 0 ? 'primary' : 'secondary' }, projectFields.length))),
+                        react_1.default.createElement(react_bootstrap_1.Accordion.Body, null,
+                            react_1.default.createElement("div", { className: "d-flex flex-wrap gap-2 mb-2" },
+                                react_1.default.createElement(react_bootstrap_1.Form.Control, { ref: knownFieldsRef, type: "text", value: enteredKnownFields, placeholder: "Enter field name", onChange: (e) => setEnteredKnownFields(e.target.value), autoComplete: "off", style: { width: 200 } }),
+                                react_1.default.createElement(react_bootstrap_1.Button, { variant: "primary", onClick: () => {
+                                        var _a;
+                                        addKnownField(enteredKnownFields);
+                                        setEnteredKnownFields('');
+                                        (_a = knownFieldsRef.current) === null || _a === void 0 ? void 0 : _a.focus();
+                                    } }, "Add Field")),
+                            react_1.default.createElement("div", { className: "d-flex flex-wrap gap-2 mb-2" }, knownFieldsElements),
+                            react_1.default.createElement("div", null,
+                                react_1.default.createElement(react_bootstrap_1.Form.Control, { type: "text", value: knownFieldsText !== null && knownFieldsText !== void 0 ? knownFieldsText : '', placeholder: knownFieldsText ? '' : 'Add a field above', onChange: (e) => setKnownFieldsText(e.target.value), style: { width: 550 } }))))),
+                react_1.default.createElement(react_bootstrap_1.Form.Text, { className: "text-muted" }, "Optionally, you can select the optional fields that will be included as headers in the generated CSV file. Custom fields are fetched from the user/org's active projects.")),
+            react_1.default.createElement("div", { className: "d-flex justify-content-end" },
+                react_1.default.createElement(react_bootstrap_1.Button, { variant: "primary", onClick: () => setLoading(true) }, "Refresh"))))));
+};
+exports.GitHubProjectFieldSettings = GitHubProjectFieldSettings;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,8 @@
         "@apollo/client": "^3.7.0",
         "bootstrap": "^5.2.2",
         "emoji-regex": "^10.2.1",
-        "export-to-csv": "^0.2.1",
         "graphql": "^16.6.0",
+        "json-2-csv": "3.18.0",
         "react-bootstrap": "^2.5.0"
       },
       "devDependencies": {
@@ -12297,6 +12297,14 @@
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
     },
+    "node_modules/deeks": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/deeks/-/deeks-2.6.0.tgz",
+      "integrity": "sha512-zu/g4fVjPreYuP11f3o5W7TeSRscpnn9LQO15lxIXu66MwOopIxj4jhLDEGMW7JkZYqWEz5JG3qs88kHNMY08g==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -12523,6 +12531,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/doc-path": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-3.0.6.tgz",
+      "integrity": "sha512-fUNXXk+4MbfKkXec41cIyD5DTPISVD0MzMPWX2qz+kL7otFtQRHCkyPaD8qmLyQpfYQWye/z7oXeeD0nQp8HYQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/doctrine": {
@@ -13637,11 +13653,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
-    },
-    "node_modules/export-to-csv": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/export-to-csv/-/export-to-csv-0.2.1.tgz",
-      "integrity": "sha512-KTbrd3CAZ0cFceJEZr1e5uiMasabeCpXq1/5uvVxDl53o4jXJHnltasQoj2NkzrxD8hU9kdwjnMhoir/7nNx/A=="
     },
     "node_modules/express": {
       "version": "4.18.1",
@@ -16423,6 +16434,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/json-2-csv": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/json-2-csv/-/json-2-csv-3.18.0.tgz",
+      "integrity": "sha512-+1lxMDaIx71QWVaENrphLb+o9xUY34nxVW6dKiRzFM2YYyxFbIkKNn4J3oVEOn/xxNtkmg8XVGmpZT+wIoi5xw==",
+      "dependencies": {
+        "deeks": "2.6.0",
+        "doc-path": "3.0.6"
+      },
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/json-format": {
@@ -33931,6 +33954,11 @@
       "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
     },
+    "deeks": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/deeks/-/deeks-2.6.0.tgz",
+      "integrity": "sha512-zu/g4fVjPreYuP11f3o5W7TeSRscpnn9LQO15lxIXu66MwOopIxj4jhLDEGMW7JkZYqWEz5JG3qs88kHNMY08g=="
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -34108,6 +34136,11 @@
       "requires": {
         "path-type": "^4.0.0"
       }
+    },
+    "doc-path": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/doc-path/-/doc-path-3.0.6.tgz",
+      "integrity": "sha512-fUNXXk+4MbfKkXec41cIyD5DTPISVD0MzMPWX2qz+kL7otFtQRHCkyPaD8qmLyQpfYQWye/z7oXeeD0nQp8HYQ=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -34987,11 +35020,6 @@
           "dev": true
         }
       }
-    },
-    "export-to-csv": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/export-to-csv/-/export-to-csv-0.2.1.tgz",
-      "integrity": "sha512-KTbrd3CAZ0cFceJEZr1e5uiMasabeCpXq1/5uvVxDl53o4jXJHnltasQoj2NkzrxD8hU9kdwjnMhoir/7nNx/A=="
     },
     "express": {
       "version": "4.18.1",
@@ -37074,6 +37102,15 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
+    },
+    "json-2-csv": {
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/json-2-csv/-/json-2-csv-3.18.0.tgz",
+      "integrity": "sha512-+1lxMDaIx71QWVaENrphLb+o9xUY34nxVW6dKiRzFM2YYyxFbIkKNn4J3oVEOn/xxNtkmg8XVGmpZT+wIoi5xw==",
+      "requires": {
+        "deeks": "2.6.0",
+        "doc-path": "3.0.6"
+      }
     },
     "json-format": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "rm -rf ./dist && tsc",
     "watch": "tsc --watch",
     "test": "echo Tests",
-    "lint": "eslint '*/**/*.{js,jsx,ts,tsx}' --quiet --fix",
+    "lint": "eslint \"*/**/*.{js,jsx,ts,tsx}\" --quiet --fix",
     "start": "npm run storybook",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "@apollo/client": "^3.7.0",
     "bootstrap": "^5.2.2",
     "emoji-regex": "^10.2.1",
-    "export-to-csv": "^0.2.1",
     "graphql": "^16.6.0",
+    "json-2-csv": "3.18.0",
     "react-bootstrap": "^2.5.0"
   }
 }

--- a/src/api/github-projectv2-api.ts
+++ b/src/api/github-projectv2-api.ts
@@ -581,7 +581,6 @@ export class ProjectFieldValue {
   }
 
   public getValue(): string | number | undefined {
-    // console.log(`${this.field.getName()}`, this.getType());
     switch (this.getType()) {
       case ProjectFieldType.ProjectV2ItemFieldDateValue:
         return this.node?.date;

--- a/src/api/github-projectv2-api.ts
+++ b/src/api/github-projectv2-api.ts
@@ -342,3 +342,84 @@ export class ProjectItem {
     return this.node?.content?.url;
   }
 }
+
+export const fetchProjectFields = async (
+  login: string,
+  isOrg: boolean,
+  projectNumber: number,
+  token: string,
+  progress?: (loaded: number, total: number) => void,
+): Promise<ProjectField[]> => {
+  const PROJECT_FIELDS_QUERY = gql`
+    query ProjectFieldsQuery(
+      $login: String!
+      $projectNumber: Int!
+      $fieldsFirst: Int
+      $fieldsAfter: String
+    ) {
+      entity: ${isOrg ? 'organization' : 'user'}(login: $login) {
+        projectV2(number: $projectNumber) {
+          fields(first: $fieldsFirst, after: $fieldsAfter) {
+            totalCount
+            edges {
+              cursor
+              node {
+                ... on ProjectV2Field {
+                  id
+                  name
+                }
+                ... on ProjectV2SingleSelectField {
+                  id
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+
+  const client = createGQLClient(token);
+  let fieldsAfter = null;
+  let queryResults = undefined;
+  let loadedEdges: { node: object }[] = [];
+  let loadedAll = false;
+  // We can only load 100 at a time. So we use cursors to load all issues.
+  while (!loadedAll) {
+    queryResults = await client.query({
+      query: PROJECT_FIELDS_QUERY,
+      variables: {
+        login,
+        projectNumber,
+        fieldsFirst: 100,
+        fieldsAfter,
+      },
+    });
+    const totalCount = queryResults.data?.entity?.projectV2?.fields?.totalCount ?? 0;
+    const edges: any[] = queryResults?.data?.entity?.projectV2?.fields?.edges ?? [];
+    loadedEdges = [...loadedEdges, ...edges];
+    fieldsAfter = edges[edges.length - 1].cursor;
+    loadedAll = loadedEdges.length === totalCount;
+    // If a progress function was provided, we can call that to update the progress bar.
+    if (progress) {
+      progress(loadedEdges.length, totalCount);
+    }
+  }
+  return loadedEdges.map((edge) => new ProjectField(edge.node));
+};
+
+export class ProjectField {
+  public node: any;
+  constructor(node: any) {
+    this.node = node;
+  }
+
+  public getName(): string | undefined {
+    return this.node?.name;
+  }
+
+  public getId(): string | undefined {
+    return this.node?.id;
+  }
+}

--- a/src/components/GitHubProjectExporter.tsx
+++ b/src/components/GitHubProjectExporter.tsx
@@ -265,7 +265,6 @@ export const GitHubProjectExporter = (props: GitHubProjectExporterProps) => {
   };
 
   const exportCsv = async (jsonData: { [key: string]: unknown }[], filename: string) => {
-    console.log('jsonData', jsonData);
     // https://npm.one/package/json-2-csv
     const csv = await json2csvAsync(jsonData, {
       emptyFieldValue: '',

--- a/src/components/GitHubProjectExporter.tsx
+++ b/src/components/GitHubProjectExporter.tsx
@@ -147,7 +147,9 @@ export const GitHubProjectExporter = (props: GitHubProjectExporterProps) => {
                   ...(selectedFieldsNames.includes('Title') && {
                     Title: (removeTitleEmojis === 'true' ? rawTitle.split(emojiRegex()).join('') : rawTitle).trim(),
                   }),
-                  Number: item.getNumber() ?? '',
+                  ...(selectedFieldsNames.includes('Number') && {
+                    Number: item.getNumber() ?? '',
+                  }),
                   Status: (removeStatusEmojis === 'true' ? rawStatus.split(emojiRegex()).join('') : rawStatus).trim(),
                   ...(selectedFieldsNames.includes('Assignees') && {
                     Assignees:
@@ -156,21 +158,37 @@ export const GitHubProjectExporter = (props: GitHubProjectExporterProps) => {
                         ?.map((a) => a.name)
                         .join(', ') ?? '',
                   }),
-                  'Assignee Usernames':
-                    item
-                      .getAssignees()
-                      ?.map((a) => a.login)
-                      .join(', ') ?? '',
+                  ...(selectedFieldsNames.includes('Assignee Usernames') && {
+                    'Assignee Usernames':
+                      item
+                        .getAssignees()
+                        ?.map((a) => a.login)
+                        .join(', ') ?? '',
+                  }),
                   ...(selectedFieldsNames.includes('Labels') && { Labels: item.getLabels()?.join(', ') ?? '' }),
-                  URL: item.getUrl() ?? '',
+                  ...(selectedFieldsNames.includes('URL') && {
+                    URL: item.getUrl() ?? '',
+                  }),
                   ...(selectedFieldsNames.includes('Milestone') && { Milestone: item.getMilestone() ?? '' }),
-                  Author: item.getAuthor()?.name ?? '',
-                  'Author Username': item.getAuthor()?.login ?? '',
-                  CreatedAt: item.getCreatedAt() ?? '',
-                  UpdatedAt: item.getUpdatedAt() ?? '',
-                  ClosedAt: item.getClosedAt() ?? '',
-                  Type: item.getType() ?? '',
-                  State: item.getState() ?? '',
+                  ...(selectedFieldsNames.includes('Author') && { Author: item.getAuthor()?.name ?? '' }),
+                  ...(selectedFieldsNames.includes('Author Username') && {
+                    'Author Username': item.getAuthor()?.login ?? '',
+                  }),
+                  ...(selectedFieldsNames.includes('CreatedAt') && {
+                    CreatedAt: item.getCreatedAt() ?? '',
+                  }),
+                  ...(selectedFieldsNames.includes('UpdatedAt') && {
+                    UpdatedAt: item.getUpdatedAt() ?? '',
+                  }),
+                  ...(selectedFieldsNames.includes('ClosedAt') && {
+                    ClosedAt: item.getClosedAt() ?? '',
+                  }),
+                  ...(selectedFieldsNames.includes('Type') && {
+                    Type: item.getType() ?? '',
+                  }),
+                  ...(selectedFieldsNames.includes('State') && {
+                    State: item.getState() ?? '',
+                  }),
                 },
               );
             });

--- a/src/components/GitHubProjectExporter.tsx
+++ b/src/components/GitHubProjectExporter.tsx
@@ -4,11 +4,13 @@ import { ExportToCsv } from 'export-to-csv';
 import React from 'react';
 import { Alert, Badge, Button, Card, Col, Container, Image, ProgressBar, Row, Spinner, Table } from 'react-bootstrap';
 import { DivProps } from 'react-html-props';
-import { fetchProjects, fetchProjectItems, Projects, Project } from '../api/github-projectv2-api';
+import { fetchProjectItems, fetchProjects, Project, Projects } from '../api/github-projectv2-api';
 import {
   EXPORTER_ACCESS_TOKEN_KEY,
   EXPORTER_COLUMN_FILTER_ENABLED_KEY,
   EXPORTER_COLUMN_FILTER_TEXT_KEY,
+  EXPORTER_FIELD_FILTER_ENABLED_KEY,
+  EXPORTER_FIELD_FILTER_TEXT_KEY,
   EXPORTER_INCLUDE_CLOSED_ITEMS_KEY,
   EXPORTER_INCLUDE_DRAFT_ISSUES_KEY,
   EXPORTER_INCLUDE_ISSUES_KEY,
@@ -16,6 +18,7 @@ import {
   EXPORTER_IS_ORG_KEY,
   EXPORTER_KNOWN_COLUMNS_DEFAULT,
   EXPORTER_KNOWN_COLUMNS_KEY,
+  EXPORTER_KNOWN_FIELDS_KEY,
   EXPORTER_LOGIN_KEY,
   EXPORTER_REMOVE_STATUS_EMOJIS_KEY,
   EXPORTER_REMOVE_TITLE_EMOJIS_KEY,
@@ -45,6 +48,12 @@ export const GitHubProjectExporter = (props: GitHubProjectExporterProps) => {
   const [knownColumnsText] = useLocalStorageState(EXPORTER_KNOWN_COLUMNS_DEFAULT, EXPORTER_KNOWN_COLUMNS_KEY);
   const knownColumns = (knownColumnsText ?? '').split(',').filter((c) => !!c);
   const selectedColumnNames = (columnFilterText ?? '').split(',').filter((c) => !!c);
+
+  const [knownFieldsText, setKnownFieldsText] = useLocalStorageState('', EXPORTER_KNOWN_FIELDS_KEY);
+  const [fieldsFilterEnabled, setFieldsFilterEnabled] = useLocalStorageState('true', EXPORTER_FIELD_FILTER_ENABLED_KEY);
+  const [fieldsFilterText, setFieldsFilterText] = useLocalStorageState(knownFieldsText, EXPORTER_FIELD_FILTER_TEXT_KEY);
+  const selectedFieldsNames = (fieldsFilterText ?? '').split(',').filter((c) => !!c);
+  const knownFields = (knownFieldsText ?? '').split(',').filter((c) => !!c);
 
   const [projects, setProjects] = React.useState<Projects | undefined>(undefined);
   const [loadProjectsError, setLoadProjectsError] = React.useState<Error | undefined>(undefined);
@@ -242,6 +251,12 @@ export const GitHubProjectExporter = (props: GitHubProjectExporterProps) => {
   const selectedColumnElements = selectedColumnNames.map((col, index) => (
     <Badge key={`${col}-${index}`} bg="primary">
       {col}
+    </Badge>
+  ));
+
+  const selectedFieldsElements = selectedFieldsNames.map((field, index) => (
+    <Badge key={`${field}-${index}`} bg="primary">
+      {field}
     </Badge>
   ));
 
@@ -471,6 +486,22 @@ export const GitHubProjectExporter = (props: GitHubProjectExporterProps) => {
                               </div>
                             ) : (
                               <Badge bg="primary">Include all statuses</Badge>
+                            )}
+                          </td>
+                        </tr>
+                        <tr>
+                          <td>Fields included</td>
+                          <td>
+                            {fieldsFilterEnabled === 'true' ? (
+                              <div className="d-flex flex-wrap gap-1">
+                                {selectedFieldsNames.length > 0 ? (
+                                  selectedFieldsElements
+                                ) : (
+                                  <Badge bg="danger">None</Badge>
+                                )}
+                              </div>
+                            ) : (
+                              <Badge bg="primary">Include all fields</Badge>
                             )}
                           </td>
                         </tr>

--- a/src/components/GitHubProjectExporterSettings.tsx
+++ b/src/components/GitHubProjectExporterSettings.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Accordion, Badge, Button, Card, Col, Container, Form, Row } from 'react-bootstrap';
 import { DivProps } from 'react-html-props';
 import { exporterPath } from './GitHubProjectExporter';
-import { GitHubProjectSpecificSettings } from './GitHubProjectSpecificSettings';
+import { GitHubProjectFieldSettings } from './GitHubProjectFieldSettings';
 import { useLocalStorageState } from './useLocalStorageState';
 
 const KEY_PREFIX = `github-projectv2-csv-exporter`;
@@ -291,7 +291,7 @@ export const GitHubExporterSettings = ({ ...props }: GitHubExporterSettingsProps
                     these known statuses appear.
                   </Form.Text>
                 </Form.Group>
-                <GitHubProjectSpecificSettings />
+                <GitHubProjectFieldSettings />
 
                 <div className="d-flex justify-content-end mt-4">
                   <a href={exporterPath}>

--- a/src/components/GitHubProjectExporterSettings.tsx
+++ b/src/components/GitHubProjectExporterSettings.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Accordion, Badge, Button, Card, Col, Container, Form, Row } from 'react-bootstrap';
 import { DivProps } from 'react-html-props';
 import { exporterPath } from './GitHubProjectExporter';
+import { GitHubProjectSpecificSettings } from './GitHubProjectSpecificSettings';
 import { useLocalStorageState } from './useLocalStorageState';
 
 const KEY_PREFIX = `github-projectv2-csv-exporter`;
@@ -21,6 +22,9 @@ export const EXPORTER_KNOWN_COLUMNS_KEY = `${KEY_PREFIX}.known-columns`;
 export const EXPORTER_KNOWN_COLUMNS_DEFAULT = `Todo,In Progress,Done`;
 export const EXPORTER_COLUMN_FILTER_ENABLED_KEY = `${KEY_PREFIX}.column-filter-enabled`;
 export const EXPORTER_COLUMN_FILTER_TEXT_KEY = `${KEY_PREFIX}.column-filter-text`;
+export const EXPORTER_KNOWN_FIELDS_KEY = `${KEY_PREFIX}.known-fields`;
+export const EXPORTER_FIELD_FILTER_ENABLED_KEY = `${KEY_PREFIX}.field-filter-enabled`;
+export const EXPORTER_FIELD_FILTER_TEXT_KEY = `${KEY_PREFIX}.field-filter-text`;
 
 export const settingsPath = '/github-projectv2-csv-exporter/?path=/story/tools-github-project-exporter--settings';
 export interface GitHubExporterSettingsProps extends DivProps {}
@@ -287,6 +291,8 @@ export const GitHubExporterSettings = ({ ...props }: GitHubExporterSettingsProps
                     these known statuses appear.
                   </Form.Text>
                 </Form.Group>
+                <GitHubProjectSpecificSettings />
+
                 <div className="d-flex justify-content-end mt-4">
                   <a href={exporterPath}>
                     <Button variant="primary">Open Exporter</Button>

--- a/src/components/GitHubProjectSpecificSettings.tsx
+++ b/src/components/GitHubProjectSpecificSettings.tsx
@@ -16,10 +16,6 @@ export interface GitHubExporterProjectSpecificSettings extends DivProps {}
 
 /**
  * Settings for a specific GitHub project
- *
- * notes: fetch project info via API:
- * - project custom fields
- * - use toggle box or something similar to the "Statuses included" from main settings page
  */
 export const GitHubProjectSpecificSettings = ({ ...props }: GitHubExporterProjectSpecificSettings) => {
   const [accessToken] = useLocalStorageState('', EXPORTER_ACCESS_TOKEN_KEY);

--- a/src/components/GitHubProjectSpecificSettings.tsx
+++ b/src/components/GitHubProjectSpecificSettings.tsx
@@ -1,0 +1,216 @@
+import React from 'react';
+import { Accordion, Badge, Button, Col, Container, Form, Row, Spinner } from 'react-bootstrap';
+import { DivProps } from 'react-html-props';
+import { fetchProjectFields, ProjectField } from '../api/github-projectv2-api';
+import {
+  EXPORTER_ACCESS_TOKEN_KEY,
+  EXPORTER_FIELD_FILTER_ENABLED_KEY,
+  EXPORTER_FIELD_FILTER_TEXT_KEY,
+  EXPORTER_IS_ORG_KEY,
+  EXPORTER_KNOWN_FIELDS_KEY,
+  EXPORTER_LOGIN_KEY,
+} from './GitHubProjectExporterSettings';
+import { useLocalStorageState } from './useLocalStorageState';
+
+export interface GitHubExporterProjectSpecificSettings extends DivProps {}
+
+/**
+ * Settings for a specific GitHub project
+ *
+ * notes: fetch project info via API:
+ * - project custom fields
+ * - use toggle box or something similar to the "Statuses included" from main settings page
+ */
+export const GitHubProjectSpecificSettings = ({ ...props }: GitHubExporterProjectSpecificSettings) => {
+  const [accessToken] = useLocalStorageState('', EXPORTER_ACCESS_TOKEN_KEY);
+  const [isOrg] = useLocalStorageState('true', EXPORTER_IS_ORG_KEY);
+  const [login] = useLocalStorageState('', EXPORTER_LOGIN_KEY);
+
+  const [projectFields, setProjectFields] = React.useState<ProjectField[] | undefined>(undefined);
+  const [loadProjectFieldsError, setLoadProjectFieldsError] = React.useState<Error | undefined>(undefined);
+
+  const [loading, setLoading] = React.useState(true);
+
+  const [knownFieldsText, setKnownFieldsText] = useLocalStorageState('', EXPORTER_KNOWN_FIELDS_KEY);
+  const [fieldsFilterEnabled, setFieldsFilterEnabled] = useLocalStorageState('true', EXPORTER_FIELD_FILTER_ENABLED_KEY);
+  const [fieldsFilterText, setFieldsFilterText] = useLocalStorageState(knownFieldsText, EXPORTER_FIELD_FILTER_TEXT_KEY);
+
+  const [enteredKnownFields, setEnteredKnownFields] = React.useState('');
+  const knownFieldsRef = React.useRef<HTMLInputElement>(null);
+
+  const selectedFieldsNames = (fieldsFilterText ?? '').split(',').filter((c) => !!c);
+  const knownFields = (knownFieldsText ?? '').split(',').filter((c) => !!c);
+
+  const addKnownField = (col: string) => {
+    setKnownFieldsText([...new Set([...knownFields, col.trim()])].join(','));
+  };
+  const deleteKnownField = (col: string) => {
+    const colsCopy = [...knownFields];
+    colsCopy.splice(colsCopy.indexOf(col), 1);
+    setKnownFieldsText(colsCopy.join(','));
+  };
+
+  const fieldNameBadgeElements = knownFields.map((colName, index) => {
+    const selected = selectedFieldsNames.includes(colName);
+    return (
+      <Badge
+        key={`col-${index}`}
+        bg={selected ? 'primary' : 'light'}
+        className={`user-select-none ${selected ? '' : 'text-black'}`}
+        onClick={() => {
+          if (!selected) {
+            setFieldsFilterText([...new Set([...selectedFieldsNames, colName])].join(','));
+            setFieldsFilterEnabled('true');
+          } else {
+            const newNames = [...selectedFieldsNames];
+            newNames.splice(newNames.indexOf(colName), 1);
+            setFieldsFilterText(newNames.join(','));
+            setFieldsFilterEnabled(`${newNames.length > 0}`);
+          }
+        }}
+        style={{ cursor: 'pointer' }}
+      >
+        {colName}
+      </Badge>
+    );
+  });
+
+  const knownFieldsElements = knownFields.map((field, index) => (
+    <Badge key={`known-col-${index}`} bg="primary">
+      <div className="d-flex gap-2 align-items-center">
+        {field}
+        <span
+          className="fw-bold"
+          style={{ cursor: 'pointer', fontSize: '120%' }}
+          onClick={() => deleteKnownField(field)}
+        >
+          &times;
+        </span>
+      </div>
+    </Badge>
+  ));
+
+  React.useEffect(() => {
+    console.log('GitHubProjectSpecificSettings: useEffect()', accessToken, login, loading);
+    if (accessToken && login && loading) {
+      fetchProjectFields(login, isOrg === 'true', 1, accessToken)
+        .then((projectFields) => {
+          setProjectFields(projectFields);
+          setKnownFieldsText(projectFields.map((f) => f.getName()).join(','));
+        })
+        .catch((e) => {
+          console.error(e);
+          // setLoadProjectsError(e);
+        })
+        .finally(() => setLoading(false));
+    }
+  }, [accessToken, login, loading, isOrg]);
+
+  return (
+    <div {...props} style={{ ...props.style }}>
+      <Container>
+        <Row>
+          <Col>
+            <p>GitHub Project Specific Settings</p>
+            {!!loading && (
+              <div className="d-flex justify-content-center align-items-center" style={{ height: 120 }}>
+                <Spinner animation="border" role="status" />
+              </div>
+            )}
+            {!loading && !!projectFields && (
+              <>
+                <Form.Group controlId="fg-fields-filter" className="mb-3">
+                  <div className="d-flex flex-wrap align-items-center gap-2 mb-2">
+                    <Form.Check
+                      label="Include the following fields:"
+                      id="fields-filter-checkbox"
+                      checked={fieldsFilterEnabled === 'true'}
+                      onChange={(e) => setFieldsFilterEnabled(`${e.target.checked}`)}
+                      className="user-select-none"
+                    />
+                    <Form.Control
+                      type="text"
+                      value={fieldsFilterText ?? ''}
+                      placeholder={fieldsFilterEnabled !== 'true' ? '' : 'Enter field name'}
+                      onChange={(e) => setFieldsFilterText(e.target.value)}
+                      style={{ width: 220 }}
+                      disabled={fieldsFilterEnabled !== 'true'}
+                    />
+                  </div>
+                  <div className="d-flex flex-wrap gap-2 ms-4">{fieldNameBadgeElements}</div>
+                </Form.Group>
+
+                <Form.Group controlId="known-fields-groups" className="mb-3">
+                  <Accordion>
+                    <Accordion.Item eventKey="0">
+                      <Accordion.Header>
+                        <div className="d-flex gap-2">
+                          Item Fields
+                          <Badge pill bg={projectFields.length > 0 ? 'primary' : 'secondary'}>
+                            {projectFields.length}
+                          </Badge>
+                        </div>
+                      </Accordion.Header>
+                      <Accordion.Body>
+                        <div className="d-flex flex-wrap gap-2 mb-2">
+                          <Form.Control
+                            ref={knownFieldsRef}
+                            type="text"
+                            value={enteredKnownFields}
+                            placeholder="Enter field name"
+                            onChange={(e) => setEnteredKnownFields(e.target.value)}
+                            autoComplete="off"
+                            style={{ width: 200 }}
+                          />
+                          <Button
+                            variant="primary"
+                            onClick={() => {
+                              addKnownField(enteredKnownFields);
+                              setEnteredKnownFields('');
+                              knownFieldsRef.current?.focus();
+                            }}
+                          >
+                            Add Field
+                          </Button>
+                        </div>
+                        <div className="d-flex flex-wrap gap-2 mb-2">{knownFieldsElements}</div>
+                        <div>
+                          <Form.Control
+                            type="text"
+                            value={knownFieldsText ?? ''}
+                            placeholder={knownFieldsText ? '' : 'Add a field above'}
+                            onChange={(e) => setKnownFieldsText(e.target.value)}
+                            style={{ width: 550 }}
+                          />
+                        </div>
+                      </Accordion.Body>
+                    </Accordion.Item>
+                  </Accordion>
+                  <Form.Text className="text-muted">
+                    Optionally, you can add the field names from your project's boards if you'd like to filter your
+                    results based on specific fieldes. Adding Known Fieldes makes it easier to filter using the "Only
+                    include issues in the following fieldes" setting above. Your CSV will also sort cards in the order
+                    these known fieldes appear.
+                  </Form.Text>
+                </Form.Group>
+              </>
+            )}
+            <Form.Group controlId="project-specific-settings" className="mb-3">
+              <div className="d-flex justify-content-end mt-4">
+                <Button
+                  variant="primary"
+                  onClick={async () => {
+                    const res = await fetchProjectFields('crimlog', true, 1, '');
+                    console.log(res);
+                  }}
+                >
+                  Test
+                </Button>
+              </div>
+            </Form.Group>
+          </Col>
+        </Row>
+      </Container>
+    </div>
+  );
+};


### PR DESCRIPTION
# Summary
- Resolves #5 
- Introduces two new features:
	- Display custom GH project fields in generated CSV output
	- Toggle all CSV headers on/off

# Details
I had to make quite a few changes in order to get this feature to work- feel free to request modifications if anything seems questionable or otherwise unacceptable:
- A new component (`GitHubProjectFieldSettings.tsx`) is added to contain the project field settings logic
- A new API method (`fetchProjectFields()`) is added to query the names (and types) of all project item fields
- I swapped out the old csv generation package [export-to-csv](https://github.com/alexcaza/export-to-csv) for [json-2-csv](https://github.com/mrodrig/json-2-csv); not only is it more up-to-date, but it also supports setting custom headers, which the old library did not have sufficient customization for
- Slightly more React state is used throughout the app, but I felt no noticeable overhead in my local env

# Testing
- Clone fork, checkout `crimlog` branch
- `npm install`
- `npm start`
- Navigate to http://localhost:6006 in your browser and proceed to [Exporter Settings](http://localhost:6006/?path=/story/tools-github-project-exporter--settings)
	- Set an access token and login value of "crimlog" (or your own project)
- On the [Exporter Settings](http://localhost:6006/?path=/story/tools-github-project-exporter--settings) page, you should be able to view several different fields as the last setting, along with the ability to toggle them on/off 
- Run an actual export in a local environment and confirm the actual CSV output matches the expected result

# Imagery
Web application:
![image](https://user-images.githubusercontent.com/35435704/207775366-1abb5c6e-063f-40ef-8b4f-ff09f9475f50.png)

CSV output:
![image](https://user-images.githubusercontent.com/35435704/207772883-1877c3a6-62a1-4e4e-a836-3db2e52de852.png)