### PR TITLE
Fix API - title is a string

### DIFF
--- a/src/api/github-projectv2-api.ts
+++ b/src/api/github-projectv2-api.ts
@@ -109,7 +109,7 @@ export class Project {
   constructor(node: any) {
     this.node = node;
   }
-  public getTitle(): number | undefined {
+  public getTitle(): string | undefined {
     return this.node?.title;
   }
   public getProjectNumber(): number | undefined {


### PR DESCRIPTION
I changed return type of getTitle function from number to string. This was probably a mistake.